### PR TITLE
Dockerfile: Cleanups and enable ARM/AArch64 builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN \
 		iasl \
 		git \
 		gcc-aarch64-linux-gnu \
+		gcc-arm-linux-gnueabihf \
 		wget \
 		zip \
 	&& DEBIAN_FRONTEND=noninteractive apt-get clean

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN \
 		nasm \
 		iasl \
 		git \
+		gcc-aarch64-linux-gnu \
 		wget \
 		zip \
 	&& DEBIAN_FRONTEND=noninteractive apt-get clean

--- a/README.md
+++ b/README.md
@@ -46,3 +46,20 @@ $ docker run --rm -it -w /home/edk2 -v $PWD/edk2:/home/edk2/edk2 \
 (docker)$ cd edk2-platforms/Vlv2TbltDevicePkg/
 (docker)$ . Build_IFWI.sh MNW2 Debug
 ```
+
+Building firmware for QEMU AArch64
+----------------------------------
+
+```
+$ docker pull 3mdeb/edk2
+$ git clone https://github.com/tianocore/edk2.git
+$ git clone https://github.com/tianocore/edk2-platforms.git
+$ git clone -b OpenSSL_1_1_0-stable https://github.com/openssl/openssl edk2/CryptoPkg/Library/OpensslLib/openssl
+$ docker run --rm -it -w /home/edk2/edk2 -v $PWD/edk2:/home/edk2/edk2 \
+-v $PWD/edk2-platforms:/home/edk2/edk2-platforms \
+-v ${CCACHE_DIR:-$HOME/.ccache}:/home/edk2/.ccache \
+3mdeb/edk2 /bin/bash
+(docker)$ . edksetup.sh
+(docker)$ make -C BaseTools
+(docker)$ GCC5_AARCH64_PREFIX=aarch64-linux-gnu- build -a AARCH64 -t GCC5 -p ArmVirtPkg/ArmVirtQemu.dsc
+```

--- a/README.md
+++ b/README.md
@@ -63,3 +63,21 @@ $ docker run --rm -it -w /home/edk2/edk2 -v $PWD/edk2:/home/edk2/edk2 \
 (docker)$ make -C BaseTools
 (docker)$ GCC5_AARCH64_PREFIX=aarch64-linux-gnu- build -a AARCH64 -t GCC5 -p ArmVirtPkg/ArmVirtQemu.dsc
 ```
+
+Building firmware for Versatile Express ARM
+-------------------------------------------
+
+```
+$ docker pull 3mdeb/edk2
+$ git clone https://github.com/tianocore/edk2.git
+$ git clone https://github.com/tianocore/edk2-platforms.git
+$ git clone -b OpenSSL_1_1_0-stable https://github.com/openssl/openssl edk2/CryptoPkg/Library/OpensslLib/openssl
+$ docker run --rm -it -w /home/edk2/edk2 -v $PWD/edk2:/home/edk2/edk2 \
+-v $PWD/edk2-platforms:/home/edk2/edk2-platforms \
+-v ${CCACHE_DIR:-$HOME/.ccache}:/home/edk2/.ccache \
+3mdeb/edk2 /bin/bash
+(docker)$ . edksetup.sh
+(docker)$ make -C BaseTools
+(docker)$ export PACKAGES_PATH=/home/edk2/edk2:/home/edk2/edk2-platforms
+(docker)$ GCC5_ARM_PREFIX=arm-linux-gnueabihf- build -a ARM -t GCC5 -p Platform/ARM/VExpressPkg/ArmVExpress-CTA15-A7.dsc
+```


### PR DESCRIPTION
Hi,

This series enable the building of EDK2 AArch64 images within your handy docker image.
Trivial cleanups around added.

Thanks,

Phil.