### PR TITLE
Update to use python 3.7 so EDK2 Unit tests pass

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 MAINTAINER Piotr Król <piotr.krol@3mdeb.com>
 
 RUN \
@@ -6,8 +6,8 @@ RUN \
 	DEBIAN_FRONTEND=noninteractive apt-get -qqy install \
 		ccache \
 		build-essential \
-		python \
-		python-pip \
+		python3.7 \
+		python3-pip \
 		qemu \
 		sudo \
 		vim \
@@ -22,7 +22,7 @@ RUN \
 		zip \
 	&& DEBIAN_FRONTEND=noninteractive apt-get clean
 
-RUN pip install -q uefi_firmware
+RUN pip3 install -q uefi_firmware
 
 RUN useradd -m edk2 && \
 	echo "edk2:edk2" | chpasswd && \


### PR DESCRIPTION
* Using python2  the python unit tests fai, to solve this a version of python that supports the arrow operator -> and datatypes is required (python > 3.6)

* The current base image (ubuntu 16.04) only supports upto python 3.5

This change adds ubutnu 18:04 as base image and python 3.7 and tests are now succeeding.